### PR TITLE
feat: Add ability to specify additional env vars for helm and add CI to push image to GHCR

### DIFF
--- a/.github/workflows/push-helm.yaml
+++ b/.github/workflows/push-helm.yaml
@@ -1,0 +1,48 @@
+name: Push Chart to OCI
+
+on:
+  push:
+    branches:
+      - coreweave
+
+jobs:
+  push-helm-chart:
+    name: Package & Push Helm Chart
+    runs-on: cw
+    container: ghcr.io/coreweave/github-actions-images/github-helm-runner:v1.4.0
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set chart version
+        id: set_version
+        run: |
+          VERSION=$(grep '^VERSION' versions.mk | awk '{print $(NF)}')
+          SHORT_SHA=$(git rev-parse --short=8 ${{ github.sha }})
+          VERSION="${VERSION}-${SHORT_SHA}"
+          VERSION=${VERSION#v}
+
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package and push helm chart
+        run: |
+          VERSION=${{ steps.set_version.outputs.VERSION }}
+
+          helm package ./deployments/helm/nvidia-device-plugin --version "$VERSION"
+
+          REPOSITORY=ghcr.io/$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+          CHART_NAME=$(yq -r .name ./deployments/helm/nvidia-device-plugin/Chart.yaml)
+          PACKAGE_FILE="${CHART_NAME}-${VERSION}.tgz"
+
+          helm push "$PACKAGE_FILE" oci://${REPOSITORY}/charts

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -137,6 +137,26 @@ spec:
         env:
           - name: MPS_ROOT
             value: {{ .Values.mps.root }}
+        {{- if typeIs "string" .Values.resourcePrefix }}
+          - name: RESOURCE_PREFIX
+            value: {{ .Values.resourcePrefix }}
+        {{- end }}
+        {{- if typeIs "string" .Values.resourceSuffix }}
+          - name: RESOURCE_SUFFIX
+            value: {{ .Values.resourceSuffix }}
+        {{- end }}
+        {{- if typeIs "string" .Values.imexChannelIds }}
+          - name: IMEX_CHANNEL_IDS
+            value: {{ .Values.imexChannelIds | quote }}
+          {{- end }}
+        {{- if typeIs "bool" .Values.imexRequired }}
+          - name: IMEX_REQUIRED
+            value: {{ .Values.imexRequired | quote }}
+        {{- end }}
+        {{- if typeIs "string" .Values.dpDisableHealthchecks }}
+          - name: DP_DISABLE_HEALTHCHECKS
+            value: {{ .Values.dpDisableHealthchecks | quote  }}
+        {{- end }}
         {{- if typeIs "string" .Values.migStrategy }}
           - name: MIG_STRATEGY
             value: {{ .Values.migStrategy }}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -148,7 +148,7 @@ spec:
         {{- if typeIs "string" .Values.imexChannelIds }}
           - name: IMEX_CHANNEL_IDS
             value: {{ .Values.imexChannelIds | quote }}
-          {{- end }}
+        {{- end }}
         {{- if typeIs "bool" .Values.imexRequired }}
           - name: IMEX_REQUIRED
             value: {{ .Values.imexRequired | quote }}

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -36,6 +36,11 @@ nvidiaDriverRoot: null
 gdsEnabled: null
 mofedEnabled: null
 deviceDiscoveryStrategy: null
+resourcePrefix: null
+resourceSuffix: null
+dpDisableHealthchecks: null
+imexChannelIds: null
+imexRequired: null
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## Description
- Patches helm chart to support addition of additional environment variables.
- Adds CI to deploy helm charts upon pushes (branches and release tags only). Each image is created as VERSION-ShortSHA (following the build-images.yaml convention), but dropping the initial "v" to conform to SemVer2 for helm versioning. It runs on push to the `coreweave` branch only, and isn't integrated to the release.yaml pipeline. I don't think we care about that here?

An example of a run: https://github.com/Irfan-Mu/k8s-device-plugin/actions/runs/14201369670/job/39788903406#step:5:1
SUNK-REF: [SUNK-795]



[SUNK-795]: https://coreweave.atlassian.net/browse/SUNK-795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ