### PR TITLE
fix: Fix push-helm pipeline

### DIFF
--- a/.github/workflows/push-helm.yaml
+++ b/.github/workflows/push-helm.yaml
@@ -28,15 +28,10 @@ jobs:
 
           echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Package and push helm chart
         run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
           VERSION=${{ steps.set_version.outputs.VERSION }}
 
           helm package ./deployments/helm/nvidia-device-plugin --version "$VERSION"


### PR DESCRIPTION
Fixes the original push-helm.yaml by not requiring docker, and using `helm registry login` directly.

Tested run here: https://github.com/Irfan-Mu/k8s-device-plugin/actions/runs/14354003336/job/40239106035

[SUNK-795]

[SUNK-795]: https://coreweave.atlassian.net/browse/SUNK-795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ