### PR TITLE
Rmalliu/feat/multi share mps

### DIFF
--- a/api/config/v1/config.go
+++ b/api/config/v1/config.go
@@ -68,12 +68,11 @@ func NewConfig(c *cli.Context, flags []cli.Flag) (*Config, error) {
 		config.Flags.NvidiaDevRoot = config.Flags.NvidiaDriverRoot
 	}
 
-	// We explicitly set sharing.mps.failRequestsGreaterThanOne = true
-	// This can be relaxed in certain cases -- such as a single GPU -- but
-	// requires additional logic around when it's OK to combine requests and
-	// makes the semantics of a request unclear.
-	if config.Sharing.MPS != nil {
-		config.Sharing.MPS.FailRequestsGreaterThanOne = true
+	// Default sharing.mps.failRequestsGreaterThanOne to true if not explicitly set in config.
+	// Set it to false in the device plugin config to allow pods to request more than one MPS-shared GPU unit.
+	if config.Sharing.MPS != nil && config.Sharing.MPS.FailRequestsGreaterThanOne == nil {
+		t := true
+		config.Sharing.MPS.FailRequestsGreaterThanOne = &t
 	}
 
 	return config, nil

--- a/api/config/v1/replicas.go
+++ b/api/config/v1/replicas.go
@@ -28,7 +28,7 @@ import (
 // ReplicatedResources defines generic options for replicating devices.
 type ReplicatedResources struct {
 	RenameByDefault            bool                 `json:"renameByDefault,omitempty"            yaml:"renameByDefault,omitempty"`
-	FailRequestsGreaterThanOne bool                 `json:"failRequestsGreaterThanOne,omitempty" yaml:"failRequestsGreaterThanOne,omitempty"`
+	FailRequestsGreaterThanOne *bool                `json:"failRequestsGreaterThanOne,omitempty" yaml:"failRequestsGreaterThanOne,omitempty"`
 	Resources                  []ReplicatedResource `json:"resources,omitempty"                  yaml:"resources,omitempty"`
 }
 
@@ -179,14 +179,11 @@ func (s *ReplicatedResources) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	failRequestsGreaterThanOne, exists := ts["failRequestsGreaterThanOne"]
-	if !exists {
-		failRequestsGreaterThanOne = []byte(`false`)
-	}
-
-	err = json.Unmarshal(failRequestsGreaterThanOne, &s.FailRequestsGreaterThanOne)
-	if err != nil {
-		return err
+	if failRequestsGreaterThanOne, exists := ts["failRequestsGreaterThanOne"]; exists {
+		err = json.Unmarshal(failRequestsGreaterThanOne, &s.FailRequestsGreaterThanOne)
+		if err != nil {
+			return err
+		}
 	}
 
 	resources, exists := ts["resources"]

--- a/cmd/mps-control-daemon/mps/daemon.go
+++ b/cmd/mps-control-daemon/mps/daemon.go
@@ -249,14 +249,15 @@ func (d *Daemon) setComputeMode(mode computeMode) error {
 	return nil
 }
 
-// perDevicePinnedMemoryLimits returns the pinned memory limits for each device.
+// perDevicePinnedDeviceMemoryLimits returns the pinned memory limits for each
+// device as the full physical memory. Per-client throttling for shared
+// (non-full-node) requests is applied by the device plugin via the
+// CUDA_MPS_PINNED_DEVICE_MEM_LIMIT env var in the Allocate response; the MPS
+// server default must be at least that high or the env var is clamped down.
 func (m *Daemon) perDevicePinnedDeviceMemoryLimits() map[string]string {
 	totalMemoryInBytesPerDevice := make(map[string]uint64)
-	replicasPerDevice := make(map[string]uint64)
 	for _, device := range m.Devices() {
-		index := device.Index
-		totalMemoryInBytesPerDevice[index] = device.TotalMemory
-		replicasPerDevice[index] += 1
+		totalMemoryInBytesPerDevice[device.Index] = device.TotalMemory
 	}
 
 	limits := make(map[string]string)
@@ -264,17 +265,18 @@ func (m *Daemon) perDevicePinnedDeviceMemoryLimits() map[string]string {
 		if totalMemory == 0 {
 			continue
 		}
-		replicas := replicasPerDevice[index]
-		limits[index] = fmt.Sprintf("%vM", totalMemory/replicas/1024/1024)
+		limits[index] = fmt.Sprintf("%vM", totalMemory/1024/1024)
 	}
 	return limits
 }
 
+// activeThreadPercentage returns the server-side default active thread
+// percentage. Set to 100 so it does not cap per-client env-var overrides;
+// per-client throttling is applied via CUDA_MPS_ACTIVE_THREAD_PERCENTAGE in
+// the Allocate response.
 func (m *Daemon) activeThreadPercentage() string {
 	if len(m.Devices()) == 0 {
 		return ""
 	}
-	replicasPerDevice := len(m.Devices()) / len(m.Devices().GetUUIDs())
-
-	return fmt.Sprintf("%d", 100/replicasPerDevice)
+	return "100"
 }

--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -30,7 +30,7 @@ RUN set -eux; \
         aarch64) ARCH='arm64' ;; \
         *) echo "unsupported architecture" ; exit 1 ;; \
     esac; \
-    wget -nv -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
+    wget -nv -O - https://go.dev/dl/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
     | tar -C /usr/local -xz
 
 ENV GOPATH /go

--- a/internal/plugin/mps.go
+++ b/internal/plugin/mps.go
@@ -19,6 +19,8 @@ package plugin
 import (
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 
 	"k8s.io/klog/v2"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
@@ -71,7 +73,7 @@ func (m *mpsOptions) waitForDaemon() error {
 	return nil
 }
 
-func (m *mpsOptions) updateReponse(response *pluginapi.ContainerAllocateResponse) {
+func (m *mpsOptions) updateReponse(response *pluginapi.ContainerAllocateResponse, grantedCount int) {
 	if m == nil || !m.enabled {
 		return
 	}
@@ -88,4 +90,54 @@ func (m *mpsOptions) updateReponse(response *pluginapi.ContainerAllocateResponse
 			HostPath:      m.hostRoot.ShmDir(m.resourceName),
 		},
 	)
+
+	// The MPS control daemon is configured with per-device defaults at full
+	// hardware. When a container has been granted every replica the plugin
+	// advertises on this node, kubelet's accounting guarantees no other pod
+	// holds any replica concurrently, so it can use the full daemon defaults —
+	// no client-side env vars are needed.
+	//
+	// For any other (non-full-node) grant, inject the 1/replicas per-device
+	// caps via the client env vars. The MPS server clamps the per-client value
+	// to no more than the daemon default; since the default is now full, these
+	// env vars are the effective cap. This preserves the historical behavior
+	// where every non-full grant got 1/replicas memory and thread percentage,
+	// regardless of how many replicas were granted.
+	devices := m.daemon.Devices()
+	total := len(devices)
+	if total == 0 || grantedCount >= total {
+		return
+	}
+
+	replicasByIndex := make(map[string]uint64)
+	totalMemoryByIndex := make(map[string]uint64)
+	for _, device := range devices {
+		replicasByIndex[device.Index]++
+		totalMemoryByIndex[device.Index] = device.TotalMemory
+	}
+
+	// All physical GPUs managed by this daemon share the same replicas value
+	// (it comes from a single config); pick any.
+	var replicasPerGPU uint64
+	for _, n := range replicasByIndex {
+		replicasPerGPU = n
+		break
+	}
+	if replicasPerGPU == 0 {
+		return
+	}
+
+	response.Envs["CUDA_MPS_ACTIVE_THREAD_PERCENTAGE"] = fmt.Sprintf("%d", 100/replicasPerGPU)
+
+	limits := make([]string, 0, len(totalMemoryByIndex))
+	for index, totalMemory := range totalMemoryByIndex {
+		if totalMemory == 0 {
+			continue
+		}
+		limits = append(limits, fmt.Sprintf("%s=%dM", index, totalMemory/replicasPerGPU/1024/1024))
+	}
+	if len(limits) > 0 {
+		sort.Strings(limits)
+		response.Envs["CUDA_MPS_PINNED_DEVICE_MEM_LIMIT"] = strings.Join(limits, ",")
+	}
 }

--- a/internal/plugin/server.go
+++ b/internal/plugin/server.go
@@ -330,7 +330,7 @@ func (plugin *nvidiaDevicePlugin) getAllocateResponse(requestIds []string) (*plu
 		}
 	}
 	if plugin.mps.enabled {
-		plugin.updateResponseForMPS(response)
+		plugin.updateResponseForMPS(response, len(requestIds))
 	}
 
 	// The following modifications are only made if at least one non-CDI device
@@ -361,8 +361,10 @@ func (plugin *nvidiaDevicePlugin) getAllocateResponse(requestIds []string) (*plu
 // updateResponseForMPS ensures that the ContainerAllocate response contains the information required to use MPS.
 // This includes per-resource pipe and log directories as well as a global daemon-specific shm
 // and assumes that an MPS control daemon has already been started.
-func (plugin nvidiaDevicePlugin) updateResponseForMPS(response *pluginapi.ContainerAllocateResponse) {
-	plugin.mps.updateReponse(response)
+// grantedCount is the number of replica IDs kubelet allocated to this container and
+// is used to decide whether to inject per-client limit env vars.
+func (plugin nvidiaDevicePlugin) updateResponseForMPS(response *pluginapi.ContainerAllocateResponse, grantedCount int) {
+	plugin.mps.updateReponse(response, grantedCount)
 }
 
 // updateResponseForCDI updates the specified response for the given device IDs.

--- a/internal/rm/rm.go
+++ b/internal/rm/rm.go
@@ -74,20 +74,14 @@ func (r *resourceManager) ValidateRequest(ids AnnotatedIDs) error {
 	// error out if more than one resource is being allocated.
 	includesReplicas := ids.AnyHasAnnotations()
 	numRequestedDevices := len(ids)
+	failRequestsGTOne := r.config.Sharing.ReplicatedResources().FailRequestsGreaterThanOne
 	switch r.config.Sharing.SharingStrategy() {
 	case spec.SharingStrategyTimeSlicing:
-		if includesReplicas && numRequestedDevices > 1 && r.config.Sharing.ReplicatedResources().FailRequestsGreaterThanOne {
+		if includesReplicas && numRequestedDevices > 1 && failRequestsGTOne != nil && *failRequestsGTOne {
 			return fmt.Errorf("%w: maximum request size for shared resources is 1; found %d", errInvalidRequest, numRequestedDevices)
 		}
 	case spec.SharingStrategyMPS:
-		// For MPS sharing, we explicitly ignore the FailRequestsGreaterThanOne
-		// value in the sharing settings.
-		// This setting was added to timeslicing after the initial release and
-		// is set to `false` to maintain backward compatibility with existing
-		// deployments. If we do extend MPS to allow multiple devices to be
-		// requested, the MPS API will be extended separately from the
-		// time-slicing API.
-		if includesReplicas && numRequestedDevices > 1 {
+		if includesReplicas && numRequestedDevices > 1 && failRequestsGTOne != nil && *failRequestsGTOne {
 			return fmt.Errorf("%w: maximum request size for shared resources is 1; found %d", errInvalidRequest, numRequestedDevices)
 		}
 	}

--- a/internal/rm/rm_test.go
+++ b/internal/rm/rm_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 )
@@ -94,7 +95,7 @@ func TestValidateRequest(t *testing.T) {
 			description: "timeslicing with two devices -- failRequestsGreaterThanOne",
 			sharing: spec.Sharing{
 				TimeSlicing: spec.ReplicatedResources{
-					FailRequestsGreaterThanOne: true,
+					FailRequestsGreaterThanOne: ptr.To(true),
 					Resources: []spec.ReplicatedResource{
 						{
 							Name:     "nvidia.com/gpu",
@@ -151,13 +152,12 @@ func TestValidateRequest(t *testing.T) {
 				"device1::1": nil,
 			},
 			requestDevicesIDs: []string{"device0::1", "device1::0"},
-			expectedError:     errInvalidRequest,
 		},
 		{
 			description: "MPS with two devices -- failRequestsGreaterThanOne",
 			sharing: spec.Sharing{
 				MPS: &spec.ReplicatedResources{
-					FailRequestsGreaterThanOne: true,
+					FailRequestsGreaterThanOne: ptr.To(true),
 					Resources: []spec.ReplicatedResource{
 						{
 							Name:     "nvidia.com/gpu",


### PR DESCRIPTION
## Summary

  ## Summary

  Enable pods on MPS-enabled GPU clusters to request more than one shared replica and, when they request all replicas, get the full GPU hardware. Two coordinated changes in this PR:

  1. **Make `failRequestsGreaterThanOne` authoritative for MPS** (commit `793753a1`). Today the flag is overridden to `true` and then ignored, so MPS resource requests > 1 are always rejected regardless of config. This change honors the configured value the same way time-slicing already does. The default remains
  `true` (reject multi-replica requests) for backward compatibility — clusters opt in by explicitly setting `sharing.mps.failRequestsGreaterThanOne: false` in the device-plugin config.
  2. **Grant full GPU resources when a container requests every replica advertised on the node** (commit `fcdd6c77`). MPS control daemon's server-side caps are raised to full per-device memory and 100% threads, and the `Allocate()` response injects `CUDA_MPS_ACTIVE_THREAD_PERCENTAGE` and
  `CUDA_MPS_PINNED_DEVICE_MEM_LIMIT` at `1/replicas` for any non-full-node grant — preserving today's behavior for partial requests, while letting all-replica grants ride unrestricted daemon defaults.

  ## Motivation
  
  The MPS control daemon sets per-client per-device caps at startup:

  - `set_default_device_pinned_mem_limit <index> <totalMem/replicas>`
  - `set_default_active_thread_percentage <100/replicas>`

  Per NVIDIA's MPS docs (appendix on `CUDA_MPS_PINNED_DEVICE_MEM_LIMIT`):

  > "The new limit will only further constrain the limit set by the control daemon … setting this environment variable to a value greater than value observed by the server will not set the limit to the higher value and thus will be ineffective."

  So the daemon default is a **hard cap** — client env vars can request less, never more. The result: even a container that's been allocated every replica ID on a node is still throttled to `1/replicas` per physical GPU. `nvidia-smi` correctly shows all GPUs because the device nodes are mounted; the MPS server
  silently caps allocations.

  ## How it works

  Two coordinated touchpoints:
  
  **1. `cmd/mps-control-daemon/mps/daemon.go`** — daemon defaults raised:
  - `perDevicePinnedDeviceMemoryLimits()` → full `device.TotalMemory` per physical index
  - `activeThreadPercentage()` → `100`

  These were the floor for every client; raising them lets the client env vars (which can only clamp down, never up) become the effective cap.

  **2. `internal/plugin/server.go` + `internal/plugin/mps.go`** — Allocate response:
  - `updateResponseForMPS` and `mpsOptions.updateReponse` now take `grantedCount int` (= `len(req.DevicesIDs)`).
  - If `grantedCount >= total advertised replicas`, no env vars are injected; the container inherits the daemon's full-hardware defaults.
  - Otherwise, the response injects:
    - `CUDA_MPS_ACTIVE_THREAD_PERCENTAGE = 100/replicas`
    - `CUDA_MPS_PINNED_DEVICE_MEM_LIMIT = "<idx>=<totalMem/replicas>M,<idx>=<totalMem/replicas>M,..."`

  Both per-physical-GPU values come from `m.daemon.Devices()` — already in scope, no new plumbing of device IDs needed.

  ## Why this is safe (no oversubscription)
  
  The full-grant branch (`grantedCount >= total`) only triggers when kubelet's device-plugin accounting has handed this single container every replica ID the plugin advertises. Kubelet's accounting guarantees:

  - Each replica ID is held by ≤1 pod at any instant.
  - The all-replicas request can only be admitted when every ID is free.
  - No other pod can be admitted (for this resource) while this pod runs.

  So at the moment unrestricted defaults apply, exactly one MPS client exists on the node. NVIDIA's documented hard cap of 60 client CUDA contexts per device (Volta+) is never the active constraint — kubelet refuses oversubscription long before MPS would.

  The "mixed allocation" footgun (a pod gets all replicas of GPU-A + some of GPU-B on a multi-GPU node) cannot satisfy `grantedCount == total` by construction; it's all-or-nothing.

  ## Operational notes
  
  - **Daemon restart is required for the new defaults to take effect.** `set_default_*` is applied once at MPS daemon startup; existing clients keep their old caps. Rolling the daemonset disrupts in-flight MPS clients — coordinate with workloads.
  - **HPC-V on MPS nodes.** The MPS device-plugin injects a `/dev/shm` bind mount into every MPS client. cwtest's per-node test pods currently also create an `emptyDir{medium:Memory}` at `/dev/shm`, stacking the two and triggering a gamble `[7D07] sys_disk_mounts` false negative. This PR doesn't touch that —
  follow-up changes in `coreweave/getnodes` (skip the emptyDir on MPS nodes) and `coreweave/gamble` (env-var-aware `/dev/shm` source check) are needed to keep HPC-V passing.
  - **Multi-resource setups.** If a node advertises more than one MPS-managed resource type, each gets its own control daemon; this change applies to all of them automatically (it's in `Daemon.Start()`).

  ## What this does NOT cover

  - **Per-physical-GPU proportional grants** for mixed/fractional requests. Anything that isn't a full-node grant gets the same `1/replicas` per-device cap as before, regardless of how many replicas it owns of any specific physical GPU. The framework's there if it's ever wanted (group `req.DevicesIDs` by UUID and
   count per-physical), but not needed for the current goal.
  - **Per-PID `set_active_thread_percentage <PID>`** via the control daemon (alternative to env vars). More complex (host PID plumbing, fork/exec doesn't propagate per-PID settings) and not needed for the all-or-nothing case.
  - **MIG.** Already rejected for MPS in `internal/plugin/mps.go`.

  ## Test plan

  - [ ] Build clean: `go build ./...`
  - [ ] Existing tests pass: `go test ./cmd/mps-control-daemon/... ./internal/plugin/...`
  - [ ] Deploy to `mps-lab` (`g884dd0`, 8× RTX PRO 6000 Blackwell, MPS replicas=10).
  - [ ] Restart the `nvidia-device-plugin-mps-control-daemon` daemonset; confirm logs show `set_default_active_thread_percentage 100` and `set_default_device_pinned_mem_limit <idx> <fullMem>M` for each GPU.
  - [ ] Schedule a pod requesting `nvidia.com/gpu: "10"` (one full physical GPU's worth of replicas). Inside the pod:
    - [ ] Verify `CUDA_MPS_ACTIVE_THREAD_PERCENTAGE` and `CUDA_MPS_PINNED_DEVICE_MEM_LIMIT` env vars are **not** set (full-node-per-GPU branch path), OR the equivalent 100% / full-memory values depending on how the resource was allocated.
    - [ ] Run a CUDA program that allocates more than `totalMem/10` pinned memory on the assigned GPU; confirm it succeeds (previously would `cudaErrorOutOfMemory`).
    - [ ] Run a kernel sized to the full SM count; observe throughput close to a dedicated-GPU baseline.
  - [ ] Schedule a pod requesting `nvidia.com/gpu: "1"` (partial). Confirm:
    - [ ] `CUDA_MPS_ACTIVE_THREAD_PERCENTAGE=10` is set.
    - [ ] `CUDA_MPS_PINNED_DEVICE_MEM_LIMIT` contains entries for each physical GPU at `totalMem/10`M.
    - [ ] A CUDA program allocating more than `totalMem/10` fails with `cudaErrorOutOfMemory` — i.e. the cap is still enforced for partial grants.
  - [ ] Schedule a pod requesting all replicas on the node (`nvidia.com/gpu: "80"` for the lab node). Confirm no env vars injected and CUDA can use the full hardware on every GPU.

  ## References

  - NVIDIA MPS — `CUDA_MPS_PINNED_DEVICE_MEM_LIMIT` / `CUDA_MPS_ACTIVE_THREAD_PERCENTAGE` semantics: https://docs.nvidia.com/deploy/mps/appendix-tools-and-interface-reference.html
  - NVIDIA MPS — 60-client-per-device cap and connection-refusal behavior: https://docs.nvidia.com/deploy/mps/when-to-use-mps.html

  🤖 Generated with [Claude Code](https://claude.com/claude-code)