### PR TITLE
feat: optional /dev/fuse injection via CW_INJECT_FUSE_DEVICE

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -169,6 +169,10 @@ spec:
           - name: PASS_DEVICE_SPECS
             value: {{ .Values.compatWithCPUManager | quote }}
         {{- end }}
+        {{- if .Values.injectFuseDevice }}
+          - name: CW_INJECT_FUSE_DEVICE
+            value: "true"
+        {{- end }}
         {{- if typeIs "string" .Values.deviceListStrategy }}
           - name: DEVICE_LIST_STRATEGY
             value: {{ .Values.deviceListStrategy }}

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -42,6 +42,13 @@ dpDisableHealthchecks: null
 imexChannelIds: null
 imexRequired: null
 
+# CoreWeave: when true, inject /dev/fuse (with the device-cgroup rw rule) into every
+# allocation, so rootless apptainer/squashfuse works in NON-privileged GPU pods (e.g.
+# SUNK slurmd) without a privileged securityContext or a separate fuse device plugin.
+# Sets CW_INJECT_FUSE_DEVICE=true on the device-plugin container. Requires a non-CDI
+# device-list strategy (PassDeviceSpecs / volume-mounts); CDI strategies not yet covered.
+injectFuseDevice: false
+
 nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""

--- a/internal/plugin/server.go
+++ b/internal/plugin/server.go
@@ -541,5 +541,21 @@ func (plugin *nvidiaDevicePlugin) apiDeviceSpecs(devRoot string, ids []string) [
 		specs = append(specs, spec)
 	}
 
+	// CoreWeave: optionally inject /dev/fuse into every allocation so rootless
+	// apptainer/squashfuse works in NON-privileged GPU pods (e.g. SUNK slurmd). This
+	// adds the device-cgroup rw rule that a plain hostPath mount cannot provide on
+	// cgroup-v2 + containerd 2.x. Opt-in via CW_INJECT_FUSE_DEVICE=true; default
+	// behavior is unchanged. /dev/fuse lives at the host /dev root, not under devRoot.
+	// NOTE: this path runs only when PassDeviceSpecs is enabled (non-CDI device-list
+	// strategy). CDI strategies allocate via updateResponseForCDI() and are not yet
+	// covered — see the chart docs / follow-up for CDI support.
+	if os.Getenv("CW_INJECT_FUSE_DEVICE") == "true" {
+		specs = append(specs, &pluginapi.DeviceSpec{
+			ContainerPath: "/dev/fuse",
+			HostPath:      "/dev/fuse",
+			Permissions:   "rw",
+		})
+	}
+
 	return specs
 }


### PR DESCRIPTION
## What

Adds an opt-in flag — `CW_INJECT_FUSE_DEVICE=true` / chart value `injectFuseDevice: true` — that injects `/dev/fuse` (with the device-cgroup `rw` rule) into device-plugin allocations. This lets **rootless apptainer / squashfuse run in non-privileged GPU pods** (e.g. SUNK slurmd) without a privileged `securityContext` or a separate fuse device plugin.

Default behavior is unchanged (flag off).

## Why

On **cgroup v2 + containerd 2.x**, mounting `/dev/fuse` into a container as a `hostPath` is **not sufficient** — `open("/dev/fuse")` is gated by the per-container device cgroup, which denies char `10:229` even for root. Only the kubelet can populate that allow-list at pod creation, via one of: `privileged: true` (all devices), a DRA driver, or **a device plugin DeviceSpec**.

Since slurmd already requests this plugin's `sunk.coreweave.com/accelerator` resource (and the plugin already returns GPU `DeviceSpec`s under `PASS_DEVICE_SPECS`), the cheapest path is to append a `/dev/fuse` `DeviceSpec` to that same allocation. The kubelet then creates the node **and** adds the cgroup rule — non-privileged.

> Note: `cdi.k8s.io/*` pod annotations do **not** work here — containerd 2.x only consumes CDI from the `CDIDevices` CRI field, not annotations.

## Change

- `internal/plugin/server.go` — `apiDeviceSpecs()` appends a `/dev/fuse` `DeviceSpec` (`HostPath`/`ContainerPath` `/dev/fuse`, `rw`) when `CW_INJECT_FUSE_DEVICE=true`.
- `deployments/helm/nvidia-device-plugin/values.yaml` — new `injectFuseDevice: false`.
- `deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml` — renders the env on the plugin container when the value is set.

## Scope / follow-up

Covers the **PassDeviceSpecs (volume-mounts) device-list strategy**, which is what SUNK uses. **CDI device-list strategies** allocate via `updateResponseForCDI()` and are **not** covered by this PR — adding a fuse CDI device through `cdiHandler` is a clean follow-up.

## Validation (live, CoreWeave SUNK test cluster `cw1690` / wm-usw09b, k8s 1.35, containerd 2.1.4)

A patched build of this image was deployed as the `sunk-nvidia-device-plugin` with `CW_INJECT_FUSE_DEVICE=true`. On a slurmd pod requesting **only `sunk.coreweave.com/accelerator: 8`** (no extra resource, **no `privileged`**):

- `/dev/fuse` present as `crw-rw-rw-` (character device)
- unprivileged (`uid 65534`) `open()` on `/dev/fuse` succeeds (was `EPERM` before)
- `apptainer exec docker://alpine …` mounts via squashfuse + user namespaces successfully

Helm render verified: env absent by default, present only with `injectFuseDevice=true`.

## Enablement (downstream)

Via SUNK chart values (subchart passthrough), once the SUNK `nvidia-device-plugin` dependency is bumped to a release containing this change:

```yaml
nvidia-device-plugin:
  enabled: true
  injectFuseDevice: true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
